### PR TITLE
Adds 'type' flag to gitops-module

### DIFF
--- a/src/commands/gitops-module.ts
+++ b/src/commands/gitops-module.ts
@@ -65,6 +65,12 @@ export const builder = (yargs: Argv<any>) => {
       describe: 'The branch where the payload has been deployed',
       demandOption: false,
     })
+    .option('type', {
+      describe: 'The type of component added to the GitOps repo.',
+      choices: ['base', 'operators', 'instances'],
+      demandOption: false,
+      default: 'base',
+    })
     .option('serverName', {
       describe: 'The name of the cluster. If not provided will use `default`',
       demandOption: false,

--- a/src/services/gitops-module/gitops-module.api.ts
+++ b/src/services/gitops-module/gitops-module.api.ts
@@ -63,6 +63,7 @@ export interface GitOpsModuleInputDefaults {
   serverName: string;
   tmpDir: string;
   contentDir: string;
+  type: string;
 }
 
 export interface GitOpsModuleResult {}

--- a/src/services/gitops-module/gitops-module.impl.ts
+++ b/src/services/gitops-module/gitops-module.impl.ts
@@ -60,6 +60,7 @@ export class GitopsModuleImpl implements GitOpsModuleApi {
         valueFiles: options.valueFiles ? options.valueFiles.split(',') : [],
         contentDir: options.contentDir || process.cwd(),
         isNamespace: options.isNamespace || false,
+        type: options.type || 'base',
       });
 
     switch (result.layer) {
@@ -199,12 +200,12 @@ export class GitopsModuleImpl implements GitOpsModuleApi {
       // create overlay config path
       const overlayPath = `${config.path}/cluster/${input.serverName}`;
 
-      this.logger.debug(`Creating overlay path: ${overlayPath}/base`);
-      await fs.mkdirp(`${repoDir}/${overlayPath}/base`);
+      this.logger.debug(`Creating overlay path: ${overlayPath}/${input.type}`);
+      await fs.mkdirp(`${repoDir}/${overlayPath}/${input.type}`);
 
       const nameSuffix = payloadRepo.branch !== 'main' && payloadRepo.branch !== 'master' ? `-${payloadRepo.branch}` : '';
       const applicationName = buildApplicationName(input.name, input.namespace, nameSuffix, input.isNamespace);
-      const applicationFile = `base/${applicationName}.yaml`;
+      const applicationFile = `${input.type}/${applicationName}.yaml`;
 
       const argoApplication: ArgoApplication = new ArgoApplication({
         name: applicationName,


### PR DESCRIPTION
- Type flag provided to support separating operators and instances

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>