### PR TITLE
Updates sync command

### DIFF
--- a/src/api/kubectl/config-map.ts
+++ b/src/api/kubectl/config-map.ts
@@ -1,4 +1,4 @@
-import {AbstractKubernetesResourceManager, KubeResource, ListOptions, Props} from './kubernetes-resource-manager';
+import {AbstractKubernetesNamespacedResource, KubeResource, ListOptions, Props} from './kubernetes-resource-manager';
 import {BuildContext, Factory, ObjectFactory} from 'typescript-ioc';
 import {AsyncKubeClient} from './client';
 
@@ -15,7 +15,7 @@ const factory: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(factory)
-export class KubeConfigMap extends AbstractKubernetesResourceManager<ConfigMap> {
+export class KubeConfigMap extends AbstractKubernetesNamespacedResource<ConfigMap> {
   constructor(props: Props) {
     super(props);
   }

--- a/src/api/kubectl/deployment.ts
+++ b/src/api/kubectl/deployment.ts
@@ -1,6 +1,6 @@
 import {BuildContext, Factory, Inject, ObjectFactory} from 'typescript-ioc';
 import {AsyncKubeClient} from './client';
-import {AbstractKubernetesResourceManager, KubeResource, Props} from './kubernetes-resource-manager';
+import {AbstractKubernetesNamespacedResource, KubeResource, Props} from './kubernetes-resource-manager';
 import {timer} from '../../util/timer';
 import {Logger} from '../../util/logger';
 
@@ -25,7 +25,7 @@ const factory: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(factory)
-export class KubeDeployment extends AbstractKubernetesResourceManager<Deployment> {
+export class KubeDeployment extends AbstractKubernetesNamespacedResource<Deployment> {
   @Inject logger: Logger;
 
   constructor(props: Props) {

--- a/src/api/kubectl/ingress.ts
+++ b/src/api/kubectl/ingress.ts
@@ -2,7 +2,7 @@ import {BuildContext, Factory, ObjectFactory} from 'typescript-ioc';
 import * as _ from 'lodash';
 
 import {AsyncKubeClient, KubeClient} from './client';
-import {AbstractKubernetesResourceManager, KubeResource, Props} from './kubernetes-resource-manager';
+import {AbstractKubernetesNamespacedResource, KubeResource, Props} from './kubernetes-resource-manager';
 
 export interface Ingress extends KubeResource {
   spec: {
@@ -36,7 +36,7 @@ const factory: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(factory)
-export class KubeIngress extends AbstractKubernetesResourceManager<Ingress> {
+export class KubeIngress extends AbstractKubernetesNamespacedResource<Ingress> {
   constructor(props: Props) {
     super(props);
   }

--- a/src/api/kubectl/kubernetes-resource-manager.spec.ts
+++ b/src/api/kubectl/kubernetes-resource-manager.spec.ts
@@ -1,5 +1,5 @@
 import {
-  AbstractKubernetesResourceManager,
+  AbstractKubernetesNamespacedResource,
   KubeBody,
   KubeResource,
   KubeResourceList,
@@ -30,7 +30,7 @@ export const testV1Provider: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(testV1Provider)
-class TestV1KubernetesResource extends AbstractKubernetesResourceManager<TestResource> {
+class TestV1KubernetesResource extends AbstractKubernetesNamespacedResource<TestResource> {
 }
 
 
@@ -45,7 +45,7 @@ export const testV1Beta1Provider: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(testV1Beta1Provider)
-class TestV1Beta1KubernetesResource extends AbstractKubernetesResourceManager<TestResource> {
+class TestV1Beta1KubernetesResource extends AbstractKubernetesNamespacedResource<TestResource> {
   constructor(props: Props) {
     super(props);
   }
@@ -56,7 +56,7 @@ describe('kubernetes-resource-manager', () => {
       expect(true).toEqual(true);
   });
 
-  let classUnderTest: AbstractKubernetesResourceManager<TestResource>;
+  let classUnderTest: AbstractKubernetesNamespacedResource<TestResource>;
   let mockClient: KubeClient;
   beforeEach(() => {
     mockClient = buildMockKubeClient();

--- a/src/api/kubectl/pod.ts
+++ b/src/api/kubectl/pod.ts
@@ -1,4 +1,4 @@
-import {AbstractKubernetesResourceManager, KubeResource, Props} from './kubernetes-resource-manager';
+import {AbstractKubernetesNamespacedResource, KubeResource, Props} from './kubernetes-resource-manager';
 import {BuildContext, Factory, ObjectFactory} from 'typescript-ioc';
 import {AsyncKubeClient} from './client';
 
@@ -15,7 +15,7 @@ const factory: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(factory)
-export class KubePod extends AbstractKubernetesResourceManager<Pod> {
+export class KubePod extends AbstractKubernetesNamespacedResource<Pod> {
   constructor(props: Props) {
     super(props);
   }

--- a/src/api/kubectl/role-binding.ts
+++ b/src/api/kubectl/role-binding.ts
@@ -1,6 +1,6 @@
 import {BuildContext, Factory, ObjectFactory} from 'typescript-ioc';
 import {AsyncKubeClient} from './client';
-import {AbstractKubernetesResourceManager, KubeResource, Props} from './kubernetes-resource-manager';
+import {AbstractKubernetesNamespacedResource, KubeResource, Props} from './kubernetes-resource-manager';
 
 export interface RoleRef {
   apiGroup: string;
@@ -30,7 +30,7 @@ const factory: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(factory)
-export class KubeRoleBinding extends AbstractKubernetesResourceManager<RoleBinding> {
+export class KubeRoleBinding extends AbstractKubernetesNamespacedResource<RoleBinding> {
   constructor(props: Props) {
     super(props);
   }

--- a/src/api/kubectl/role.ts
+++ b/src/api/kubectl/role.ts
@@ -1,6 +1,6 @@
 import {BuildContext, Container, Factory, ObjectFactory} from 'typescript-ioc';
 import {AsyncKubeClient} from './client';
-import {AbstractKubernetesResourceManager, KubeResource, Props} from './kubernetes-resource-manager';
+import {AbstractKubernetesNamespacedResource, KubeResource, Props} from './kubernetes-resource-manager';
 
 export interface RoleRule {
   apiGroups: string[];
@@ -29,7 +29,7 @@ const factory: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(factory)
-export class KubeRole extends AbstractKubernetesResourceManager<Role> {
+export class KubeRole extends AbstractKubernetesNamespacedResource<Role> {
   constructor(props: Props) {
     super(props);
   }

--- a/src/api/kubectl/route.ts
+++ b/src/api/kubectl/route.ts
@@ -2,7 +2,7 @@ import {BuildContext, Factory, ObjectFactory} from 'typescript-ioc';
 import * as _ from 'lodash';
 
 import {AsyncOcpClient} from './client';
-import {AbstractKubernetesResourceManager, KubeResource, Props} from './kubernetes-resource-manager';
+import {AbstractKubernetesNamespacedResource, KubeResource, Props} from './kubernetes-resource-manager';
 
 export interface Route extends KubeResource {
   spec: {
@@ -35,7 +35,7 @@ const factory: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(factory)
-export class OcpRoute extends AbstractKubernetesResourceManager<Route> {
+export class OcpRoute extends AbstractKubernetesNamespacedResource<Route> {
   constructor(props: Props) {
     super(props);
   }

--- a/src/api/kubectl/secrets.ts
+++ b/src/api/kubectl/secrets.ts
@@ -1,6 +1,6 @@
 import {BuildContext, Factory, ObjectFactory} from 'typescript-ioc';
 import {AsyncKubeClient} from './client';
-import {AbstractKubernetesResourceManager, KubeResource, ListOptions, Props} from './kubernetes-resource-manager';
+import {AbstractKubernetesNamespacedResource, KubeResource, ListOptions, Props} from './kubernetes-resource-manager';
 import {decode as base64decode} from '../../util/base64';
 
 export interface Secret<T = any> extends KubeResource {
@@ -18,7 +18,7 @@ const factory: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(factory)
-export class KubeSecret extends AbstractKubernetesResourceManager<Secret> {
+export class KubeSecret extends AbstractKubernetesNamespacedResource<Secret> {
   constructor(props: Props) {
     super(props);
   }

--- a/src/api/kubectl/security-context-contraints.ts
+++ b/src/api/kubectl/security-context-contraints.ts
@@ -1,0 +1,26 @@
+import {AbstractKubernetesClusterResource, KubeMetadata, KubeResource, Props} from './kubernetes-resource-manager';
+import {BuildContext, Factory, ObjectFactory} from 'typescript-ioc';
+import {AsyncKubeClient} from './client';
+
+export interface SecurityContextContraints<M = KubeMetadata> extends KubeResource<M> {
+  users: string[];
+  groups: string[];
+}
+
+const factory: ObjectFactory = (context: BuildContext) => {
+  return new KubeSecurityContextConstraints({
+    client: context.resolve(AsyncKubeClient),
+    group: 'security.openshift.io',
+    version: 'v1',
+    name: 'securitycontextconstraints',
+    kind: 'SecurityContextConstraints',
+    crd: true,
+  })
+}
+
+@Factory(factory)
+export class KubeSecurityContextConstraints extends AbstractKubernetesClusterResource<SecurityContextContraints> {
+  constructor(props: Props) {
+    super(props);
+  }
+}

--- a/src/api/kubectl/service-account.ts
+++ b/src/api/kubectl/service-account.ts
@@ -1,6 +1,6 @@
 import {BuildContext, Container, Factory, ObjectFactory} from 'typescript-ioc';
 
-import {AbstractKubernetesResourceManager, KubeResource, Props} from './kubernetes-resource-manager';
+import {AbstractKubernetesNamespacedResource, KubeResource, Props} from './kubernetes-resource-manager';
 import {AsyncKubeClient} from './client';
 
 export interface ServiceAccount extends KubeResource {
@@ -17,7 +17,7 @@ const factory: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(factory)
-export class KubeServiceAccount extends AbstractKubernetesResourceManager<ServiceAccount> {
+export class KubeServiceAccount extends AbstractKubernetesNamespacedResource<ServiceAccount> {
   constructor(props: Props) {
     super(props);
   }

--- a/src/api/kubectl/tekton-pipeline-resource.ts
+++ b/src/api/kubectl/tekton-pipeline-resource.ts
@@ -1,7 +1,7 @@
 import {BuildContext, Factory, ObjectFactory} from 'typescript-ioc';
 
 import {AsyncKubeClient} from './client';
-import {AbstractKubernetesResourceManager, KubeResource, Props} from './kubernetes-resource-manager';
+import {AbstractKubernetesNamespacedResource, KubeResource, Props} from './kubernetes-resource-manager';
 
 export interface TektonPipelineResource extends KubeResource {
   spec: {
@@ -25,7 +25,7 @@ const factory: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(factory)
-export class KubeTektonPipelineResource extends AbstractKubernetesResourceManager<TektonPipelineResource> {
+export class KubeTektonPipelineResource extends AbstractKubernetesNamespacedResource<TektonPipelineResource> {
   constructor(props: Props) {
     super(props);
   }

--- a/src/api/kubectl/tekton-pipeline-run.ts
+++ b/src/api/kubectl/tekton-pipeline-run.ts
@@ -1,7 +1,7 @@
 import {BuildContext, Factory, ObjectFactory} from 'typescript-ioc';
 
 import {AsyncKubeClient} from './client';
-import {AbstractKubernetesResourceManager, KubeMetadata, KubeResource, Props} from './kubernetes-resource-manager';
+import {AbstractKubernetesNamespacedResource, KubeMetadata, KubeResource, Props} from './kubernetes-resource-manager';
 
 export interface TektonPipelineRun<M = KubeMetadata> extends KubeResource<M> {
   spec: {
@@ -42,7 +42,7 @@ const factory: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(factory)
-export class KubeTektonPipelineRun extends AbstractKubernetesResourceManager<TektonPipelineRun> {
+export class KubeTektonPipelineRun extends AbstractKubernetesNamespacedResource<TektonPipelineRun> {
   constructor(props: Props) {
     super(props);
   }

--- a/src/api/kubectl/tekton-pipeline.ts
+++ b/src/api/kubectl/tekton-pipeline.ts
@@ -1,7 +1,7 @@
 import {BuildContext, Factory, ObjectFactory} from 'typescript-ioc';
 
 import {AsyncKubeClient} from './client';
-import {AbstractKubernetesResourceManager, KubeResource, Props} from './kubernetes-resource-manager';
+import {AbstractKubernetesNamespacedResource, KubeResource, Props} from './kubernetes-resource-manager';
 
 export interface TektonPipelineParam {
   type?: 'string' | 'array';
@@ -33,7 +33,7 @@ const factory: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(factory)
-export class KubeTektonPipeline extends AbstractKubernetesResourceManager<TektonPipeline> {
+export class KubeTektonPipeline extends AbstractKubernetesNamespacedResource<TektonPipeline> {
   constructor(props: Props) {
     super(props);
   }

--- a/src/api/kubectl/tekton-task.ts
+++ b/src/api/kubectl/tekton-task.ts
@@ -1,7 +1,7 @@
 import {BuildContext, Factory, ObjectFactory} from 'typescript-ioc';
 
 import {AsyncKubeClient} from './client';
-import {AbstractKubernetesResourceManager, KubeResource, Props} from './kubernetes-resource-manager';
+import {AbstractKubernetesNamespacedResource, KubeResource, Props} from './kubernetes-resource-manager';
 
 export interface TektonTask extends KubeResource {
   spec: {
@@ -33,7 +33,7 @@ const factory: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(factory)
-export class KubeTektonTask extends AbstractKubernetesResourceManager<TektonTask> {
+export class KubeTektonTask extends AbstractKubernetesNamespacedResource<TektonTask> {
   constructor(props: Props) {
     super(props);
   }

--- a/src/api/kubectl/tekton-trigger-binding.ts
+++ b/src/api/kubectl/tekton-trigger-binding.ts
@@ -1,7 +1,7 @@
 import {BuildContext, Factory, ObjectFactory} from 'typescript-ioc';
 
 import {AsyncKubeClient} from './client';
-import {AbstractKubernetesResourceManager, KubeResource, Props} from './kubernetes-resource-manager';
+import {AbstractKubernetesNamespacedResource, KubeResource, Props} from './kubernetes-resource-manager';
 
 export interface TriggerBinding extends KubeResource {
     spec: {
@@ -24,7 +24,7 @@ const factory: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(factory)
-export class KubeTektonTriggerBinding extends AbstractKubernetesResourceManager<TriggerBinding> {
+export class KubeTektonTriggerBinding extends AbstractKubernetesNamespacedResource<TriggerBinding> {
     constructor(props: Props) {
         super(props);
     }

--- a/src/api/kubectl/tekton-trigger-event-listener.ts
+++ b/src/api/kubectl/tekton-trigger-event-listener.ts
@@ -1,7 +1,7 @@
 import {BuildContext, Container, Factory, ObjectFactory} from 'typescript-ioc';
 
 import {AsyncKubeClient} from './client';
-import {AbstractKubernetesResourceManager, KubeResource, Props} from './kubernetes-resource-manager';
+import {AbstractKubernetesNamespacedResource, KubeResource, Props} from './kubernetes-resource-manager';
 
 export interface TriggerBindingRef_v0_4 {
     name: string;
@@ -81,7 +81,7 @@ const factory: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(factory)
-export class KubeTektonTriggerEventListener extends AbstractKubernetesResourceManager<TriggerEventListener<TriggerDefinition_v0_4 | TriggerDefinition_v0_6>> {
+export class KubeTektonTriggerEventListener extends AbstractKubernetesNamespacedResource<TriggerEventListener<TriggerDefinition_v0_4 | TriggerDefinition_v0_6>> {
     constructor(props: Props) {
         super(props);
     }

--- a/src/api/kubectl/tekton-trigger-template.ts
+++ b/src/api/kubectl/tekton-trigger-template.ts
@@ -2,7 +2,7 @@ import {BuildContext, Factory, ObjectFactory} from 'typescript-ioc';
 
 import {AsyncKubeClient} from './client';
 import {
-  AbstractKubernetesResourceManager,
+  AbstractKubernetesNamespacedResource,
   KubeResource,
   Props,
   TemplateKubeMetadata
@@ -31,7 +31,7 @@ const factory: ObjectFactory = (context: BuildContext) => {
 };
 
 @Factory(factory)
-export class KubeTektonTriggerTemplate extends AbstractKubernetesResourceManager<TriggerTemplate> {
+export class KubeTektonTriggerTemplate extends AbstractKubernetesNamespacedResource<TriggerTemplate> {
   constructor(props: Props) {
     super(props);
   }

--- a/src/commands/namespace.ts
+++ b/src/commands/namespace.ts
@@ -26,6 +26,12 @@ export const builder = (yargs: Argv<any>) => {
       default: 'default',
       type: 'string',
     })
+    .option('tekton', {
+      alias: 'p',
+      describe: 'flag indicating the tekton pipeline service account should be given privileged scc',
+      default: false,
+      type: 'boolean'
+    })
     .option('verbose', {
       describe: 'flag to produce more verbose logging',
       type: 'boolean'

--- a/src/services/namespace/namespace-options.model.ts
+++ b/src/services/namespace/namespace-options.model.ts
@@ -3,4 +3,5 @@ export class NamespaceOptionsModel {
   namespace: string;
   templateNamespace: string;
   serviceAccount: string;
+  tekton?: boolean;
 }


### PR DESCRIPTION
- Adds `--tekton` flag to add privileged scc to tekton pipeline service account
- Adds SCC kube api to support SCC interactions

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>