### PR TITLE
Updates sync command

### DIFF
--- a/src/api/kubectl/role-binding.ts
+++ b/src/api/kubectl/role-binding.ts
@@ -11,7 +11,7 @@ export interface RoleRef {
 export interface RoleSubject {
   kind: string;
   name: string;
-  namespace: string;
+  namespace?: string;
 }
 
 export interface RoleBinding extends KubeResource {

--- a/src/commands/namespace.ts
+++ b/src/commands/namespace.ts
@@ -33,6 +33,18 @@ export const builder = (yargs: Argv<any>) => {
       default: false,
       type: 'boolean'
     })
+    .option('argocd', {
+      alias: 'a',
+      describe: 'flag indicating that argocd should be given permission to manage the namespace',
+      default: false,
+      type: 'boolean'
+    })
+    .option('argocdNamespace', {
+      alias: 'x',
+      describe: 'the namespace where argocd is running',
+      default: 'openshift-gitops',
+      type: 'string'
+    })
     .option('verbose', {
       describe: 'flag to produce more verbose logging',
       type: 'boolean'

--- a/src/services/namespace/namespace-options.model.ts
+++ b/src/services/namespace/namespace-options.model.ts
@@ -4,4 +4,6 @@ export class NamespaceOptionsModel {
   templateNamespace: string;
   serviceAccount: string;
   tekton?: boolean;
+  argocd?: boolean;
+  argocdNamespace?: string;
 }


### PR DESCRIPTION
- Adds --argocd flag and optional argocdNamespace parameter to create a rolebinding giving argocd admin permissions in the namespace

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>