### PR TITLE
gitops-namespace and gitops-module command option update

### DIFF
--- a/src/commands/gitops-module.ts
+++ b/src/commands/gitops-module.ts
@@ -113,7 +113,7 @@ export const builder = (yargs: Argv<any>) => {
         describe: 'Flag indicating that the GitOps application should be configured to perform a cascading delete.',
         type: 'boolean',
         demandOption: false,
-        default: false,
+        default: true,
       },
       'tmpDir': {
         describe: 'The temp directory where the gitops repo should be checked out',

--- a/src/commands/gitops-namespace.ts
+++ b/src/commands/gitops-namespace.ts
@@ -101,7 +101,7 @@ export const builder = (yargs: Argv<any>) => {
       describe: 'Flag indicating that the GitOps application should be configured to perform a cascading delete.',
       type: 'boolean',
       demandOption: false,
-      default: false,
+      default: true,
     })
     .option('tmpDir', {
       describe: 'The temp directory where the gitops repo should be checked out',


### PR DESCRIPTION
- Changes cascadingDelete flag to default to true so the finalizer is added to the ArgoCD application by default

closes #364

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>