### PR TITLE
Adds support for gitops modules from remote helm charts

### DIFF
--- a/src/commands/gitops-module.ts
+++ b/src/commands/gitops-module.ts
@@ -24,6 +24,22 @@ export const builder = (yargs: Argv<any>) => {
         type: 'string',
         demandOption: false,
       },
+      'helmRepoUrl': {
+        alias: ['r'],
+        description: 'The helm repo url that should be used for the application logic',
+        type: 'string',
+        demandOption: false
+      },
+      'helmChart': {
+        description: 'The name of the helm chart in the helm repo that should be used',
+        type: 'string',
+        demandOption: false
+      },
+      'helmChartVersion': {
+        description: 'The version of the helm chart in the helm repo that should be used',
+        type: 'string',
+        demandOption: false
+      },
       'namespace': {
         alias: 'n',
         type: 'string',

--- a/src/commands/gitops-namespace.ts
+++ b/src/commands/gitops-namespace.ts
@@ -26,6 +26,22 @@ export const builder = (yargs: Argv<any>) => {
         demandOption: false,
         default: 'default'
       },
+      'helmRepoUrl': {
+        alias: ['r'],
+        description: 'The helm repo url that should be used for the application logic',
+        type: 'string',
+        demandOption: false
+      },
+      'helmChart': {
+        description: 'The name of the helm chart in the helm repo that should be used',
+        type: 'string',
+        demandOption: false
+      },
+      'helmChartVersion': {
+        description: 'The version of the helm chart in the helm repo that should be used',
+        type: 'string',
+        demandOption: false
+      },
       'gitopsConfigFile': {
         describe: 'Name of yaml or json file that contains the gitops config values',
         type: 'string',

--- a/src/services/gitops-module/gitops-module.api.ts
+++ b/src/services/gitops-module/gitops-module.api.ts
@@ -61,6 +61,9 @@ export interface GitOpsModuleInputBase {
   gitopsConfig: GitOpsConfig;
   ignoreDiff?: string;
   caCert?: string;
+  helmRepoUrl?: string;
+  helmChart?: string;
+  helmChartVersion?: string;
 }
 export interface GitOpsModuleInputDefaults {
   isNamespace: boolean;


### PR DESCRIPTION
- Adds helmRepoUrl, helmChart, and helmChartVersion options for the gitops-namespace and gitops-module commands
- Configures gitops repo with helm chart info when provided

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>