### PR TITLE
Creates the cert dir before writing in gitops-init

### DIFF
--- a/src/services/gitops-init/gitops-init.service.ts
+++ b/src/services/gitops-init/gitops-init.service.ts
@@ -94,6 +94,7 @@ const buildGitCredentials = async (options: GitopsInitOptions): Promise<Credenti
     if (!certFile) {
       certFile = join(options.tmpDir, 'git-server.crt')
 
+      await mkdirp(options.tmpDir)
       await promises.writeFile(certFile, options.caCert.cert)
     }
 


### PR DESCRIPTION
Signed-off-by: Sean Sundberg <seansund@us.ibm.com>